### PR TITLE
Comment out Prometheus scrape targets for missing services

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -26,15 +26,17 @@ scrape_configs:
     static_configs:
       - targets: ["localhost:9090"]
 
-  # Docker metrics via cAdvisor
-  - job_name: "docker"
-    static_configs:
-      - targets: ["cadvisor:8080"]
+  # Uncomment after adding cadvisor to docker-compose.yml
+  # # Docker metrics via cAdvisor
+  # - job_name: "docker"
+  #   static_configs:
+  #     - targets: ["cadvisor:8080"]
 
-  # Host metrics via Node Exporter
-  - job_name: "node_exporter"
-    static_configs:
-      - targets: ["node-exporter:9100"]
+  # Uncomment after adding node-exporter to docker-compose.yml
+  # # Host metrics via Node Exporter
+  # - job_name: "node_exporter"
+  #   static_configs:
+  #     - targets: ["node-exporter:9100"]
 
   # Telegraf metrics
   - job_name: "telegraf"
@@ -47,16 +49,18 @@ scrape_configs:
     static_configs:
       - targets: ["tautulli:8181"]
 
-  # Netdata metrics
-  - job_name: "netdata"
-    metrics_path: "/api/v1/allmetrics"
-    params:
-      format: [prometheus]
-    honor_labels: true
-    static_configs:
-      - targets: ["netdata:19999"]
+  # Uncomment after adding netdata to docker-compose.yml
+  # # Netdata metrics
+  # - job_name: "netdata"
+  #   metrics_path: "/api/v1/allmetrics"
+  #   params:
+  #     format: [prometheus]
+  #   honor_labels: true
+  #   static_configs:
+  #     - targets: ["netdata:19999"]
 
-  # Plex Exporter metrics
-  - job_name: "plex_exporter"
-    static_configs:
-      - targets: ["plex-exporter:9594"]
+  # Uncomment after adding plex-exporter to docker-compose.yml
+  # # Plex Exporter metrics
+  # - job_name: "plex_exporter"
+  #   static_configs:
+  #     - targets: ["plex-exporter:9594"]


### PR DESCRIPTION
## Summary
- Comment out Prometheus scrape jobs for services not defined in docker-compose.yml: cadvisor, node-exporter, netdata, plex-exporter
- Keep active scrape jobs for prometheus (self), telegraf, and tautulli
- Each commented block has an "Uncomment after adding X to docker-compose.yml" note

These phantom targets would generate constant scrape errors in the Prometheus logs.

## Test plan
- [ ] Verify `docker compose up -d prometheus` starts without scrape errors
- [ ] Verify Telegraf and Tautulli metrics are still scraped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled monitoring scrape jobs for cAdvisor, node-exporter, netdata, and plex-exporter in the monitoring configuration. These services are no longer scraped for metrics, while their configuration templates remain available for future use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->