### PR TITLE
Restore Radarr/Sonarr, overhaul README, add repo guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Something in the stack isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report. Please fill out the fields below so we can reproduce the issue.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of what went wrong and what you expected instead.
+      placeholder: When I run `docker compose up -d`, the Plex container restarts in a loop...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Clone the repo at commit ...
+        2. Copy `.env.example` to `.env` and set ...
+        3. Run `docker compose up -d`
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: affected-service
+    attributes:
+      label: Which service(s) are affected?
+      placeholder: plex, radarr, tracearr, ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Output of `docker compose logs <service>` for the affected service(s). Redact secrets first.
+      render: shell
+
+  - type: input
+    id: docker-version
+    attributes:
+      label: Docker / Docker Compose version
+      description: Output of `docker --version` and `docker compose version`.
+      placeholder: Docker 27.x / Compose v2.30.x
+    validations:
+      required: true
+
+  - type: input
+    id: host-os
+    attributes:
+      label: Host OS
+      placeholder: Ubuntu 24.04, Unraid 7.0, ...
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: env-checked
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I ran `docker compose config` and it parsed without errors
+          required: true
+        - label: I have `DB_PASSWORD`, `JWT_SECRET`, and `COOKIE_SECRET` set in `.env`
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/joshdev8/AutoPlexx/discussions
+    about: Ask "how do I do X" questions, share setup tips, or discuss ideas in Discussions instead of filing an issue.
+  - name: Plex Support
+    url: https://support.plex.tv/
+    about: Issues specific to Plex Media Server itself (not this stack) belong with Plex support.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new service to include, a config improvement, or a workflow change
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the gap or pain point, not just the proposed solution.
+      placeholder: I want the stack to also handle subtitles, but Bazarr isn't currently included...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What service, config, or convention would you add or change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Optional — other approaches you ruled out and why.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Optional — links, screenshots, or related projects.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+AutoPlexx is a Docker Compose stack that orchestrates a Plex Media Server ecosystem — there is no application source code to build, lint, or test. Work here means editing `docker-compose.yml`, the `.env`/`.env.example` contract, or the Kometa / Telegraf / Prometheus config files.
+
+## Common commands
+
+```bash
+docker compose config                       # validate compose + env interpolation
+docker compose up -d                        # start all services
+docker compose up -d <service>              # (re)start a single service after editing it
+docker compose logs -f <service>            # tail one service's logs
+docker compose pull && docker compose up -d # update images (Watchtower also does this automatically)
+docker compose down                         # stop everything (volumes preserved)
+```
+
+There is no test suite. After changing `docker-compose.yml`, always run `docker compose config` to catch interpolation errors before bringing services up.
+
+## Architecture notes that aren't obvious from a glance
+
+**Network isolation matters.** Services are split across four bridge networks and one host-mode service. A service can only reach another if they share a network — adding a new service requires picking the right one (or declaring multiple):
+
+- `monitoring_network` — tautulli, grafana, telegraf, watchtower
+- `media_network` — seerr, radarr, sonarr
+- `download_network` — transmission, watchlistarr, cleanarr, requestrr, radarr, sonarr
+- `tracearr-network` — tracearr, timescale (PostgreSQL), redis
+- **host network** — plex only (required for proper streaming/discovery)
+
+Radarr and Sonarr are deliberately on both `media_network` (so Seerr can submit requests) and `download_network` (so Watchlistarr/Transmission can reach them).
+
+**Tracearr is the only "app" in the stack.** Everything else is a single off-the-shelf container. Tracearr is a three-container subsystem (app + TimescaleDB + Redis) with healthcheck-gated `depends_on`, and it is the only service whose env vars use the `${VAR:?must be set}` fail-fast form — `DB_PASSWORD`, `JWT_SECRET`, and `COOKIE_SECRET` are required or the stack will refuse to start. Its external port is `3001` mapped to internal `3000` because Grafana already owns `3000` on the host.
+
+**Volume paths are intentionally user-specific.** All bind mounts are rooted at `${USERDIR}` from `.env`. When advising the user, do not assume any particular host path layout — the README explicitly tells them to update paths to match their drive mounts.
+
+**Prometheus config is orphaned.** `prometheus/prometheus.yml` exists and references `telegraf:9273` and `tautulli:8181` as scrape targets, but there is no `prometheus` service in `docker-compose.yml`. Treat it as a stub for users who want to add Prometheus themselves — don't assume metrics are being scraped today.
+
+**Transmission VPN is aspirational.** The README claims VPN support and `.env.example` has `OPENVPN_*` variables, but the active image is plain `linuxserver/transmission` with no VPN sidecar or `haugene/transmission-openvpn` config. If the user wants real VPN tunneling, that's a change, not a fix.
+
+**Plex claim tokens expire in ~4 minutes.** `PLEX_CLAIM` must be set in `.env` immediately before `docker compose up -d` on first run. If the user reports a Plex auth issue on first boot, this is almost always why.
+
+## Kometa (plex-meta-manager) layout
+
+The mounted config directory is `plex-meta-manager/config/`. Its structure is referenced explicitly by `config.yml`:
+
+- `config.yml` — top-level Kometa config (Plex/TMDb/Tautulli/Trakt/OMDb/MDBList credentials via `${PMM_*}` env vars; library mappings for `Movies` and `TV Shows`)
+- `Movies/Movies.yml`, `Movies/Overlays.yml` — collection and overlay definitions for the Movies library (Movies.yml is ~1200 lines)
+- `TV Shows/TV Shows.yml`, `TV Shows/Overlays.yml` — same for TV
+- `Playlists.yml` — top-level playlist definitions
+
+`config.yml` loads both the named files *and* `folder: config/Movies/` / `config/TV Shows/`, so any new `.yml` dropped in those folders is auto-picked-up. Note the literal space in the `TV Shows` path — quote it in shell commands.
+
+## Env var contract
+
+`.env.example` is the source of truth for what `.env` needs. The values fall into three categories:
+
+1. **Hard-required** (stack won't start): `DB_PASSWORD`, `JWT_SECRET`, `COOKIE_SECRET` (all Tracearr).
+2. **Effectively required for the feature to work**: `PUID`/`PGID`/`TZ`/`USERDIR` (everything), `PLEX_CLAIM` (first-boot only), `PMM_*` (Kometa).
+3. **Documented but unused by the current compose file**: `OPENVPN_*`, `DOCKER_INFLUXDB_*`, `RADARR_*`, `SONARR_*`, `EMAIL`/`PASSWORD`/`HTTP_*`/`DOMAIN*`. These exist for the "not included but recommended" services in the README or aspirational features — don't add validation for them and don't assume the user has them set.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,34 @@
-# AutoPlexx - Fully Automated Plex Media Server Setup
-<br>
+# AutoPlexx — Fully Automated Plex Media Server Setup
+
 <div align="center">
     <img src="https://github.com/joshdev8/AutoPlexx/assets/19192998/b367872b-1d48-40cf-b2f5-1aac30a10512" />
 </div>
-<br>
-<br>
 
-A fully automated [Plex Media Server](https://www.plex.tv/) ecosystem using [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
+<div align="center">
+
+[![License](https://img.shields.io/github/license/joshdev8/AutoPlexx?style=flat-square)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/joshdev8/AutoPlexx?style=flat-square)](https://github.com/joshdev8/AutoPlexx/stargazers)
+[![Last commit](https://img.shields.io/github/last-commit/joshdev8/AutoPlexx?style=flat-square)](https://github.com/joshdev8/AutoPlexx/commits/main)
+[![Issues](https://img.shields.io/github/issues/joshdev8/AutoPlexx?style=flat-square)](https://github.com/joshdev8/AutoPlexx/issues)
+[![Docker Compose](https://img.shields.io/badge/Docker_Compose-v2+-2496ED?style=flat-square&logo=docker&logoColor=white)](https://docs.docker.com/compose/)
+[![Plex](https://img.shields.io/badge/Plex-EBAF00?style=flat-square&logo=plex&logoColor=black)](https://www.plex.tv/)
+
+</div>
+
+A complete, opinionated [Plex Media Server](https://www.plex.tv/) stack delivered as a single [Docker Compose](https://docs.docker.com/compose/) file — bootstrap streaming, request handling, library automation, downloads, and monitoring with one command.
+
+## Why AutoPlexx?
+
+- **One command, full stack** — Plex, request handling (Seerr), library automation (Radarr/Sonarr), downloads, monitoring, and metadata curation all wired together. `docker compose up -d` and you're done.
+- **Pre-built Kometa config included** — IMDb Top 250 / Trakt / streaming-service collections, daily rotating playlists, and resolution/HDR overlays are ready to run, not a blank YAML you fill in over weeks.
+- **Network-isolated by design** — four separate Docker networks split streaming, request flow, downloading, and monitoring so a misbehaving service can't talk to the rest.
+- **Stream analytics in the box** — Tracearr ships built-in for concurrent-stream monitoring, geolocation, and account-sharing detection alongside Tautulli's usage reporting.
 
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) (v2+)
-- A Plex account and [claim token](https://www.plex.tv/claim)
-- A VPN provider account (for Transmission)
+- A Plex account and a [claim token](https://www.plex.tv/claim) — generate this **immediately before** your first `docker compose up`; claim tokens expire roughly 4 minutes after they're issued
+- Values for `DB_PASSWORD`, `JWT_SECRET`, and `COOKIE_SECRET` in `.env` — Tracearr refuses to start without them and will fail the whole stack's `up` command
 
 ## Getting Started
 
@@ -29,15 +45,64 @@ A fully automated [Plex Media Server](https://www.plex.tv/) ecosystem using [Doc
     cp .env.example .env
     ```
 
-    > **Note:** Tracearr requires `DB_PASSWORD`, `JWT_SECRET`, and `COOKIE_SECRET` to be set or it will fail to start.
-
-3. Update the volume paths in `docker-compose.yml` to match your hard drive mount points.
+3. Set `USERDIR` in `.env` to the parent directory where configs and media should live. All services bind-mount under `${USERDIR}/<service>`, so this one variable controls where everything lands — you don't normally need to edit `docker-compose.yml` itself.
 
 4. Start all services:
 
     ```bash
     docker compose up -d
     ```
+
+## Common Operations
+
+```bash
+docker compose ps                                # show running services
+docker compose logs -f <service>                 # tail one service's logs
+docker compose restart <service>                 # restart one service after editing its config
+docker compose pull && docker compose up -d      # update images (Watchtower also does this on a schedule)
+docker compose down                              # stop everything (named volumes preserved)
+docker compose config                            # validate YAML + env interpolation without starting anything
+```
+
+## Architecture
+
+```mermaid
+flowchart LR
+    User([User])
+    Watchlist[Plex Watchlist]
+
+    User -->|streams from| Plex
+    User -->|requests via| Seerr
+    Watchlist -->|synced by| Watchlistarr
+
+    Seerr -->|submits to| Radarr
+    Seerr -->|submits to| Sonarr
+    Watchlistarr -->|drives| Radarr
+    Watchlistarr -->|drives| Sonarr
+
+    Radarr -->|sends torrents| Transmission
+    Sonarr -->|sends torrents| Transmission
+    Transmission -->|completed files| Plex
+
+    Plex -->|stream activity| Tautulli
+    Plex -->|stream activity| Tracearr
+    Tracearr --> TimescaleDB[(TimescaleDB)]
+    Tracearr --> Redis[(Redis)]
+
+    Telegraf -->|host + container metrics| Grafana
+    Tautulli -->|usage data| Grafana
+```
+
+See [Network Architecture](#network-architecture) below for the exact network membership of each service.
+
+## Screenshots
+
+<!--
+TODO: drop screenshots into a `docs/screenshots/` directory and reference them below.
+Suggested captures: Plex web UI, Seerr discover page, Radarr/Sonarr libraries, Tautulli dashboard, Grafana panels, Tracearr dashboard.
+-->
+
+> Screenshots of the running stack — Plex, Seerr, Tautulli, Grafana, and Tracearr — coming soon. Contributions welcome via PR.
 
 ## Services
 
@@ -46,13 +111,16 @@ A fully automated [Plex Media Server](https://www.plex.tv/) ecosystem using [Doc
 | Service | Description | Port |
 |---------|-------------|------|
 | [Plex](https://www.plex.tv/) | Central media server | `32400` (host network) |
-| [Kometa](https://kometa.wiki/) | Automates metadata curation, collections, and overlays | N/A (scheduled task) |
+
+A ready-to-use [Kometa](https://kometa.wiki/) (Plex Meta Manager) configuration is included for automated collections and overlays, but Kometa itself is not part of `docker-compose.yml` — see [Kometa Configuration](#kometa-configuration) for how to run it.
 
 ### Content Management
 
 | Service | Description | Port |
 |---------|-------------|------|
 | [Seerr](https://github.com/seerr-team/seerr) | Content request and management interface | `5055` |
+| [Radarr](https://radarr.video/) | Movie management and downloading | `7878` |
+| [Sonarr](https://sonarr.tv/) | TV show management and downloading | `8989` |
 | [Watchlistarr](https://github.com/nylonee/watchlistarr) | Syncs Plex watchlist to Radarr/Sonarr | N/A |
 | [Cleanarr](https://github.com/se1exin/Cleanarr) | Finds and removes duplicate content | N/A |
 | [Requestrr](https://github.com/darkalfx/requestrr) | Discord bot for content requests | `4545` |
@@ -61,7 +129,7 @@ A fully automated [Plex Media Server](https://www.plex.tv/) ecosystem using [Doc
 
 | Service | Description | Port |
 |---------|-------------|------|
-| [Transmission](https://transmissionbt.com/) | Torrent client with VPN support | `9091` |
+| [Transmission](https://transmissionbt.com/) | Torrent client | `9091` |
 
 ### Monitoring
 
@@ -84,8 +152,6 @@ A fully automated [Plex Media Server](https://www.plex.tv/) ecosystem using [Doc
 
 These services pair well with this stack but are not included in the default `docker-compose.yml`. See their respective docs to add them:
 
-- **[Radarr](https://radarr.video/)** - Movie management and downloading
-- **[Sonarr](https://sonarr.tv/)** - TV show management and downloading
 - **[Lidarr](https://lidarr.audio/)** - Music management and downloading
 - **[Bazarr](https://www.bazarr.media/)** - Subtitle management
 - **[Prowlarr](https://prowlarr.com/)** - Indexer management for Radarr/Sonarr
@@ -97,15 +163,24 @@ These services pair well with this stack but are not included in the default `do
 Services are isolated into separate Docker networks:
 
 - **`monitoring_network`** - Tautulli, Grafana, Telegraf, Watchtower
-- **`media_network`** - Seerr
-- **`download_network`** - Transmission, Watchlistarr, Cleanarr, Requestrr
+- **`media_network`** - Seerr, Radarr, Sonarr
+- **`download_network`** - Transmission, Watchlistarr, Cleanarr, Requestrr, Radarr, Sonarr
 - **`tracearr-network`** - Tracearr, TimescaleDB, Redis
 
-Plex runs in host network mode for optimal streaming performance.
+Plex runs in host network mode for optimal streaming performance. Radarr and Sonarr are attached to both `media_network` (so Seerr can submit requests to them) and `download_network` (so Watchlistarr and Transmission can reach them).
 
 ## Kometa Configuration
 
-The `plex-meta-manager/config/` directory contains Kometa configurations for automated collection and overlay management:
+The `plex-meta-manager/config/` directory contains a ready-to-use [Kometa](https://kometa.wiki/) configuration. Kometa itself is not in `docker-compose.yml` — run it as a one-shot container on whatever schedule you prefer (cron, systemd timer, or a separate compose file):
+
+```bash
+docker run --rm \
+  -v "$(pwd)/plex-meta-manager/config:/config" \
+  --env-file .env \
+  kometateam/kometa
+```
+
+The bundled config drives:
 
 - **Movies** - IMDb Top 250, TMDb trending, Trakt lists, Oscar categories, genre collections, streaming service collections, holiday collections, and more
 - **TV Shows** - Popular/trending, streaming networks, genres, studios (Marvel, DC), year-based collections

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,40 @@ services:
       interval: 15s
       retries: 3
 
+  radarr:
+    container_name: radarr
+    image: linuxserver/radarr
+    networks:
+      - media_network
+      - download_network
+    ports:
+      - "7878:7878"
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - ${USERDIR}/radarr/config:/config
+      - ${USERDIR}/plex/media:/media
+    restart: unless-stopped
+
+  sonarr:
+    container_name: sonarr
+    image: linuxserver/sonarr
+    networks:
+      - media_network
+      - download_network
+    ports:
+      - "8989:8989"
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - ${USERDIR}/sonarr/config:/config
+      - ${USERDIR}/plex/media:/media
+    restart: unless-stopped
+
   # ============ MEDIA CENTER ============
   watchlistarr:
     container_name: watchlistarr
@@ -216,5 +250,7 @@ volumes:
   cleanarr:
   requestrr:
   transmission:
+  radarr:
+  sonarr:
   timescale_data:
   redis_data:


### PR DESCRIPTION
- Add Radarr (7878) and Sonarr (8989) to docker-compose.yml, attached to both media_network and download_network so Seerr can request and Watchlistarr/Transmission can reach them.
- README: badges, "Why AutoPlexx?" section, Mermaid architecture diagram, Common Operations, Kometa run instructions, screenshots placeholder; move Radarr/Sonarr from "recommended" into the Content Management table; drop the Transmission VPN claim.
- Add CLAUDE.md describing repo layout, network isolation, env-var contract, and Kometa config structure.
- Add .github/ISSUE_TEMPLATE/ bug_report, feature_request, and config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Radarr and Sonarr services for automated movie and TV show management

* **Documentation**
  * Implemented standardized GitHub Issue templates for bug reports and feature requests
  * Added comprehensive project documentation covering architecture and configuration details
  * Enhanced README with setup instructions, common operations, and service information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joshdev8/AutoPlexx/pull/32)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->