### PR TITLE
Add community health files and discoverability touches

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR change, and why? Keep it to a few sentences. -->
+
+## Type of change
+
+- [ ] New service or feature (`feat/`)
+- [ ] Bug fix (`fix/`)
+- [ ] Documentation (`docs/`)
+- [ ] Repo hygiene / config (`chore/` or `cleanup/`)
+- [ ] Kometa / config files
+
+## Validation
+
+- [ ] `docker compose config` parses cleanly
+- [ ] Affected service(s) start with `docker compose up -d <service>` and logs look healthy
+- [ ] If a new service was added: it is on the correct network(s) and listed in the README service table
+- [ ] If a new env var was added: it is in `.env.example` with a placeholder and a comment
+
+## Related
+
+<!-- Linked issues, discussions, or PRs. Use "Closes #123" to auto-close on merge. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its Code of Conduct. The full text is available at the link above.
+
+## Summary
+
+We want AutoPlexx to be a welcoming space for anyone who wants to use, contribute to, or learn from it. In short:
+
+- Be respectful in issues, PRs, and discussions.
+- Assume good faith; ask clarifying questions before assuming the worst.
+- Critique ideas and code, not people.
+- Harassment, personal attacks, and discriminatory language are not acceptable.
+
+## Scope
+
+This Code of Conduct applies to all project spaces — the GitHub repository (issues, PRs, discussions, commit messages), and any other forum maintained as part of the project.
+
+## Reporting
+
+If you experience or witness behavior that violates this Code of Conduct, report it privately to the maintainer at <joshcain8@gmail.com>. Reports will be reviewed and handled confidentially.
+
+## Enforcement
+
+The maintainer is responsible for clarifying and enforcing these standards. Responses to violations may include a warning, temporary or permanent ban from project spaces, or removal of contributions, depending on severity. The full enforcement guidelines are described in the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to AutoPlexx
+
+Thanks for your interest in improving AutoPlexx. This repo is a Docker Compose stack — there's no application source code, build step, or test suite. Most contributions edit `docker-compose.yml`, the `.env.example` contract, the Kometa config under `plex-meta-manager/config/`, or the README.
+
+## Before you open a PR
+
+1. **Validate the compose file.** This catches YAML typos and env interpolation errors before anything boots:
+
+    ```bash
+    docker compose config
+    ```
+
+2. **Try the change locally.** For service edits, bring the affected service up with `docker compose up -d <service>` and tail its logs:
+
+    ```bash
+    docker compose logs -f <service>
+    ```
+
+3. **Don't commit secrets.** `.env` is gitignored — only `.env.example` (placeholder values) belongs in the repo. The Tracearr-required `DB_PASSWORD`, `JWT_SECRET`, and `COOKIE_SECRET` must never appear in commits.
+
+## Branching and commits
+
+Recent history follows a `type/short-description` pattern:
+
+- `feat/` — new service or capability
+- `fix/` — bug fix in an existing service or config
+- `docs/` — README, CLAUDE.md, or other documentation
+- `chore/` — repo hygiene, CI, config files
+- `cleanup/` — removing dead files or unused config
+
+Keep commit subjects in the imperative ("Add Radarr to compose", not "Added Radarr"). Use the commit body for the *why* when it isn't obvious from the diff.
+
+## What makes a good PR
+
+- **One concern per PR.** A README rewrite and a new service should be separate PRs unless the docs explicitly cover the service being added.
+- **Update the relevant docs.** New service? Add it to the README's service table and the network architecture section. New env var? Add it to `.env.example` with a placeholder and a comment explaining what it does.
+- **Network membership is deliberate.** Services on a different bridge network cannot reach each other. When adding a service, pick the right network(s) — see [CLAUDE.md](CLAUDE.md) for the current layout.
+- **Fill in the PR template.** It exists so reviewers don't have to ask the same questions every time.
+
+## Questions vs. issues
+
+- **"How do I…"** or "should we consider…" → [Discussions](https://github.com/joshdev8/AutoPlexx/discussions)
+- **"This is broken"** → [Bug report](https://github.com/joshdev8/AutoPlexx/issues/new?template=bug_report.yml)
+- **"Add this service / change this convention"** → [Feature request](https://github.com/joshdev8/AutoPlexx/issues/new?template=feature_request.yml)
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you agree to abide by its terms.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue in AutoPlexx — for example, a default configuration that leaks credentials, an insecure port exposure in `docker-compose.yml`, or a secret accidentally committed to the repo — please report it privately rather than opening a public issue.
+
+**Preferred:** use GitHub's [private vulnerability reporting](https://github.com/joshdev8/AutoPlexx/security/advisories/new). This keeps the report confidential until a fix is ready.
+
+**Alternative:** email <joshcain8@gmail.com> with the subject line `AutoPlexx security`.
+
+Please include:
+
+- A description of the issue and where it lives (file path, service, line if applicable)
+- Steps to reproduce, or a proof-of-concept config
+- The version / commit of AutoPlexx you tested against
+- Your assessment of impact (information disclosure, RCE, credential leak, etc.)
+
+You'll get an acknowledgement within a few days. Fixes are issued on a best-effort basis — this is a hobbyist project, not a commercial product.
+
+## Scope
+
+AutoPlexx is a Docker Compose configuration that orchestrates third-party container images. In-scope issues are things that **this repo** controls:
+
+- Insecure defaults in `docker-compose.yml` (exposed ports, missing isolation, weak auth defaults)
+- Secrets or credentials committed to the repo
+- Documentation that recommends an insecure setup
+- The bundled Kometa, Telegraf, and Prometheus configs
+
+Vulnerabilities in upstream images (Plex, Radarr, Sonarr, Transmission, Grafana, etc.) should be reported directly to those projects.
+
+## Required secrets — handle with care
+
+The Tracearr service requires three secrets that must be present in `.env` for the stack to start:
+
+- `DB_PASSWORD`
+- `JWT_SECRET`
+- `COOKIE_SECRET`
+
+These are never to be committed. `.env` is gitignored; only `.env.example` (placeholder values) belongs in the repo. If you accidentally commit a real secret, rotate it immediately — git history is hard to clean once pushed.


### PR DESCRIPTION
## Summary

- Adds `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, and `.github/PULL_REQUEST_TEMPLATE.md` so the repo's community profile is complete on GitHub.
- Repo settings applied alongside this PR (not in the diff):
  - `homepage` set to `https://github.com/joshdev8/AutoPlexx#readme`
  - GitHub Discussions enabled (the existing `.github/ISSUE_TEMPLATE/config.yml` already links to Discussions; this makes that link work).

## Type of change

- [x] Documentation (`docs/`)
- [x] Repo hygiene / config (`chore/` or `cleanup/`)

## Validation

- [x] `docker compose config` parses cleanly (no compose changes in this PR)
- [x] All new files render correctly on GitHub (Contributor Covenant link, security advisory link)
- [x] PR template matches the style of the existing issue templates

## Related

Follows up on the README overhaul in #32. No linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Pull Request template with structured guidelines for contributions.
  * Adopted Contributor Covenant Code of Conduct.
  * Added Contributing guidelines covering workflow, validation steps, and contribution conventions.
  * Established Security policy for vulnerability reporting and secret management guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joshdev8/AutoPlexx/pull/33)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->