### PR TITLE
Add Prowlarr, Portainer, and Bazarr as default services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,15 @@ There is no test suite. After changing `docker-compose.yml`, always run `docker 
 
 **Network isolation matters.** Services are split across four bridge networks and one host-mode service. A service can only reach another if they share a network — adding a new service requires picking the right one (or declaring multiple):
 
-- `monitoring_network` — tautulli, grafana, telegraf, watchtower
-- `media_network` — seerr, radarr, sonarr
+- `monitoring_network` — tautulli, grafana, telegraf, watchtower, portainer
+- `media_network` — seerr, radarr, sonarr, prowlarr, bazarr
 - `download_network` — transmission, watchlistarr, cleanarr, requestrr, radarr, sonarr
 - `tracearr-network` — tracearr, timescale (PostgreSQL), redis
 - **host network** — plex only (required for proper streaming/discovery)
 
-Radarr and Sonarr are deliberately on both `media_network` (so Seerr can submit requests) and `download_network` (so Watchlistarr/Transmission can reach them).
+Radarr and Sonarr are deliberately on both `media_network` (so Seerr, Prowlarr, and Bazarr can reach them) and `download_network` (so Watchlistarr/Transmission can reach them). Prowlarr and Bazarr only need `media_network` because their only inbound/outbound peers are the *arr APIs.
+
+**Portainer mounts the Docker socket.** `portainer/portainer-ce` binds `/var/run/docker.sock` read-write, which is root-equivalent access to the host. If a user reports security concerns, this is the relevant exposure — flag it before recommending Portainer-based workflows.
 
 **Tracearr is the only "app" in the stack.** Everything else is a single off-the-shelf container. Tracearr is a three-container subsystem (app + TimescaleDB + Redis) with healthcheck-gated `depends_on`, and it is the only service whose env vars use the `${VAR:?must be set}` fail-fast form — `DB_PASSWORD`, `JWT_SECRET`, and `COOKIE_SECRET` are required or the stack will refuse to start. Its external port is `3001` mapped to internal `3000` because Grafana already owns `3000` on the host.
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,13 @@ flowchart LR
     Seerr -->|submits to| Sonarr
     Watchlistarr -->|drives| Radarr
     Watchlistarr -->|drives| Sonarr
+    Prowlarr -->|provides indexers to| Radarr
+    Prowlarr -->|provides indexers to| Sonarr
 
     Radarr -->|sends torrents| Transmission
     Sonarr -->|sends torrents| Transmission
     Transmission -->|completed files| Plex
+    Bazarr -->|fetches subtitles for| Plex
 
     Plex -->|stream activity| Tautulli
     Plex -->|stream activity| Tracearr
@@ -121,6 +124,8 @@ A ready-to-use [Kometa](https://kometa.wiki/) (Plex Meta Manager) configuration 
 | [Seerr](https://github.com/seerr-team/seerr) | Content request and management interface | `5055` |
 | [Radarr](https://radarr.video/) | Movie management and downloading | `7878` |
 | [Sonarr](https://sonarr.tv/) | TV show management and downloading | `8989` |
+| [Prowlarr](https://prowlarr.com/) | Indexer manager that feeds Radarr/Sonarr | `9696` |
+| [Bazarr](https://www.bazarr.media/) | Subtitle management for Radarr/Sonarr libraries | `6767` |
 | [Watchlistarr](https://github.com/nylonee/watchlistarr) | Syncs Plex watchlist to Radarr/Sonarr | N/A |
 | [Cleanarr](https://github.com/se1exin/Cleanarr) | Finds and removes duplicate content | N/A |
 | [Requestrr](https://github.com/darkalfx/requestrr) | Discord bot for content requests | `4545` |
@@ -139,6 +144,7 @@ A ready-to-use [Kometa](https://kometa.wiki/) (Plex Meta Manager) configuration 
 | [Grafana](https://grafana.com/) | Metrics visualization | `3000` |
 | [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) | Metrics collection agent | N/A |
 | [Tracearr](https://github.com/connorgallopo/tracearr) | Stream tracking and account sharing detection | `3001` |
+| [Portainer](https://www.portainer.io/) | Docker management UI ([note on socket access](#a-note-on-portainer)) | `9000` |
 
 ### Infrastructure
 
@@ -153,21 +159,22 @@ A ready-to-use [Kometa](https://kometa.wiki/) (Plex Meta Manager) configuration 
 These services pair well with this stack but are not included in the default `docker-compose.yml`. See their respective docs to add them:
 
 - **[Lidarr](https://lidarr.audio/)** - Music management and downloading
-- **[Bazarr](https://www.bazarr.media/)** - Subtitle management
-- **[Prowlarr](https://prowlarr.com/)** - Indexer management for Radarr/Sonarr
-- **[Jackett](https://github.com/Jackett/Jackett)** - Torrent indexer aggregator
-- **[Portainer](https://www.portainer.io/)** - Docker management UI
+- **[Jackett](https://github.com/Jackett/Jackett)** - Torrent indexer aggregator (Prowlarr covers most use cases)
 
 ## Network Architecture
 
 Services are isolated into separate Docker networks:
 
-- **`monitoring_network`** - Tautulli, Grafana, Telegraf, Watchtower
-- **`media_network`** - Seerr, Radarr, Sonarr
+- **`monitoring_network`** - Tautulli, Grafana, Telegraf, Watchtower, Portainer
+- **`media_network`** - Seerr, Radarr, Sonarr, Prowlarr, Bazarr
 - **`download_network`** - Transmission, Watchlistarr, Cleanarr, Requestrr, Radarr, Sonarr
 - **`tracearr-network`** - Tracearr, TimescaleDB, Redis
 
-Plex runs in host network mode for optimal streaming performance. Radarr and Sonarr are attached to both `media_network` (so Seerr can submit requests to them) and `download_network` (so Watchlistarr and Transmission can reach them).
+Plex runs in host network mode for optimal streaming performance. Radarr and Sonarr are attached to both `media_network` (so Seerr, Prowlarr, and Bazarr can reach them) and `download_network` (so Watchlistarr and Transmission can reach them).
+
+### A note on Portainer
+
+Portainer mounts the host's Docker socket (`/var/run/docker.sock`) so it can manage every container. **This grants the Portainer UI root-equivalent access to the host** — anyone who logs in can stop, restart, or exec into any container, including those handling secrets. Set a strong admin password on first launch and don't expose port `9000` to the public internet.
 
 ## Kometa Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,20 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
 
+  portainer:
+    container_name: portainer
+    image: portainer/portainer-ce:latest
+    networks:
+      - monitoring_network
+    ports:
+      - "9000:9000"
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    restart: unless-stopped
+
   # ============ MEDIA MANAGEMENT ============
   seerr:
     image: ghcr.io/seerr-team/seerr:latest
@@ -119,6 +133,37 @@ services:
       - TZ=${TZ}
     volumes:
       - ${USERDIR}/sonarr/config:/config
+      - ${USERDIR}/plex/media:/media
+    restart: unless-stopped
+
+  prowlarr:
+    container_name: prowlarr
+    image: linuxserver/prowlarr
+    networks:
+      - media_network
+    ports:
+      - "9696:9696"
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - ${USERDIR}/prowlarr/config:/config
+    restart: unless-stopped
+
+  bazarr:
+    container_name: bazarr
+    image: linuxserver/bazarr
+    networks:
+      - media_network
+    ports:
+      - "6767:6767"
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - ${USERDIR}/bazarr/config:/config
       - ${USERDIR}/plex/media:/media
     restart: unless-stopped
 
@@ -252,5 +297,8 @@ volumes:
   transmission:
   radarr:
   sonarr:
+  prowlarr:
+  bazarr:
+  portainer_data:
   timescale_data:
   redis_data:


### PR DESCRIPTION
## Summary

- Adds three services to `docker-compose.yml` that were previously listed as "not included but recommended":
  - **Prowlarr** (port `9696`, `media_network`) — single indexer manager that feeds Radarr/Sonarr, replacing per-*arr indexer config.
  - **Portainer** (port `9000`, `monitoring_network`) — Docker management UI. Mounts `/var/run/docker.sock` for full host control.
  - **Bazarr** (port `6767`, `media_network`) — subtitle management against the same `${USERDIR}/plex/media` library Radarr/Sonarr already write to.
- README and CLAUDE.md updated: service tables, network architecture lists, Mermaid diagram (now shows Prowlarr → *arrs and Bazarr → Plex), and a callout flagging that Portainer's socket mount grants root-equivalent host access.

## Type of change

- [x] New service or feature (`feat/`)
- [x] Documentation (`docs/`)

## Validation

- [x] `docker compose config` parses cleanly with placeholder env values
- [x] All three services are on the correct network(s) and listed in the README service table
- [x] No new env vars required — services use the existing `PUID`/`PGID`/`TZ`/`USERDIR` contract
- [ ] Tested locally on a host with real `.env` (deferred — config edits only)

## Related

Follows up on the README overhaul (#32) and community health files (#33). No linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Portainer service for Docker container management.
  * Added Prowlarr service for indexer management.
  * Added Bazarr service for subtitle downloads.

* **Documentation**
  * Updated network architecture documentation with refined service memberships across monitoring, media, and download networks.
  * Expanded Portainer security documentation with explicit warning about host-level access via Docker socket permissions.
  * Updated component diagrams and service listings to reflect newly added services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joshdev8/AutoPlexx/pull/34)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->