### PR TITLE
Add FlareSolverr, Maintainerr, Decluttarr, Checkrr (issue #37)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ TRANSMISSION_RPC_PASSWORD=
 # Host port to expose Grafana on. Defaults to 3000 if unset.
 GRAFANA_PORT=3000
 
+# ============ Decluttarr (queue cleanup for Radarr/Sonarr) ============
+# These keys come from Radarr's Settings -> General -> API Key (and Sonarr's
+# equivalent) AFTER the stack is running. Decluttarr starts fine with them
+# blank — it just skips any service whose key isn't set.
+RADARR_API_KEY=
+SONARR_API_KEY=
+
 # ============ Tracearr (required — stack will refuse to start if blank) ============
 # Use strong random strings, e.g. `openssl rand -base64 32`
 DB_PASSWORD=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ There is no test suite. After changing `docker-compose.yml`, always run `docker 
 **Network isolation matters.** Services are split across four bridge networks and one host-mode service. A service can only reach another if they share a network — adding a new service requires picking the right one (or declaring multiple):
 
 - `monitoring_network` — tautulli, grafana, telegraf, watchtower, portainer, prometheus, cadvisor, node-exporter
-- `media_network` — seerr, radarr, sonarr, prowlarr, bazarr
-- `download_network` — transmission, watchlistarr, cleanarr, requestrr, radarr, sonarr
+- `media_network` — seerr, radarr, sonarr, prowlarr, bazarr, flaresolverr, maintainerr, checkrr
+- `download_network` — transmission, watchlistarr, cleanarr, requestrr, decluttarr, radarr, sonarr
 - `tracearr-network` — tracearr, timescale (PostgreSQL), redis
 - **host network** — plex only (required for proper streaming/discovery)
 
@@ -62,5 +62,6 @@ The mounted config directory is `plex-meta-manager/config/`. Its structure is re
 
 1. **Hard-required** (stack won't start): `DB_PASSWORD`, `JWT_SECRET`, `COOKIE_SECRET` (Tracearr); `OPENVPN_PROVIDER`, `OPENVPN_CONFIG`, `OPENVPN_USERNAME`, `OPENVPN_PASSWORD` (Transmission VPN). All use the `${VAR:?must be set}` fail-fast form.
 2. **Effectively required for the feature to work**: `PUID`/`PGID`/`TZ`/`USERDIR` (everything), `PLEX_CLAIM` (first-boot only), `GRAFANA_PORT` (defaults to 3000 if unset), `LOCAL_NETWORK` (Transmission, defaults to `192.168.0.0/16`), `PMM_*` (Kometa), `TRANSMISSION_RPC_USERNAME`/`TRANSMISSION_RPC_PASSWORD` (optional web UI auth).
+3. **Populated after first boot**: `RADARR_API_KEY`, `SONARR_API_KEY` (Decluttarr). These come from the Radarr/Sonarr UIs after the stack is up — Decluttarr starts fine with them blank and skips any service whose key isn't set. **Note:** this is a real exception to the "every var in `.env.example` is consumed by compose" rule above — flag this chicken-and-egg to users on first-boot questions, since the *arr API keys are only obtainable post-`up`.
 
-If a user mentions an env var not in this list (e.g. `RADARR_API_KEY`, `DOCKER_INFLUXDB_*`, `PLEX_TOKEN`), it's from an older version of the stack — not consumed today.
+If a user mentions an env var not in this list (e.g. `DOCKER_INFLUXDB_*`, `PLEX_TOKEN`, `EMAIL`/`PASSWORD`), it's from an older version of the stack — not consumed today.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,11 @@ A ready-to-use [Kometa](https://kometa.wiki/) (Plex Meta Manager) configuration 
 | [Sonarr](https://sonarr.tv/) | TV show management and downloading | `8989` |
 | [Prowlarr](https://prowlarr.com/) | Indexer manager that feeds Radarr/Sonarr | `9696` |
 | [Bazarr](https://www.bazarr.media/) | Subtitle management for Radarr/Sonarr libraries | `6767` |
+| [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) | Cloudflare bypass proxy for Prowlarr indexers | `8191` |
+| [Maintainerr](https://github.com/jorenn92/Maintainerr) | Rule-based Plex library cleanup (auto-remove watched/aged items) | `6246` |
 | [Watchlistarr](https://github.com/nylonee/watchlistarr) | Syncs Plex watchlist to Radarr/Sonarr | N/A |
+| [Decluttarr](https://github.com/ManiMatter/decluttarr) | Removes stalled / failed downloads from \*arr queues | N/A |
+| [Checkrr](https://github.com/aetaric/checkrr) | Scans media files for codec / corruption issues | `8585` |
 | [Cleanarr](https://github.com/se1exin/Cleanarr) | Finds and removes duplicate content | N/A |
 | [Requestrr](https://github.com/darkalfx/requestrr) | Discord bot for content requests | `4545` |
 
@@ -174,8 +178,8 @@ These services pair well with this stack but are not included in the default `do
 Services are isolated into separate Docker networks:
 
 - **`monitoring_network`** - Tautulli, Grafana, Telegraf, Watchtower, Portainer, Prometheus, cAdvisor, node-exporter
-- **`media_network`** - Seerr, Radarr, Sonarr, Prowlarr, Bazarr
-- **`download_network`** - Transmission, Watchlistarr, Cleanarr, Requestrr, Radarr, Sonarr
+- **`media_network`** - Seerr, Radarr, Sonarr, Prowlarr, Bazarr, FlareSolverr, Maintainerr, Checkrr
+- **`download_network`** - Transmission, Watchlistarr, Cleanarr, Requestrr, Decluttarr, Radarr, Sonarr
 - **`tracearr-network`** - Tracearr, TimescaleDB, Redis
 
 Plex runs in host network mode for optimal streaming performance. Radarr and Sonarr are attached to both `media_network` (so Seerr, Prowlarr, and Bazarr can reach them) and `download_network` (so Watchlistarr and Transmission can reach them).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,6 +225,36 @@ services:
       - ${USERDIR}/plex/media:/media
     restart: unless-stopped
 
+  # Cloudflare bypass proxy. Prowlarr (and any other indexer client)
+  # routes requests through this to reach indexer sites behind Cloudflare.
+  flaresolverr:
+    container_name: flaresolverr
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    networks:
+      - media_network
+    ports:
+      - "8191:8191"
+    environment:
+      - LOG_LEVEL=info
+      - TZ=${TZ}
+    restart: unless-stopped
+
+  # Rule-based Plex library maintenance (auto-remove watched / aged items).
+  maintainerr:
+    container_name: maintainerr
+    image: ghcr.io/jorenn92/maintainerr:latest
+    networks:
+      - media_network
+    ports:
+      - "6246:6246"
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - ${USERDIR}/maintainerr/data:/opt/data
+    restart: unless-stopped
+
   # ============ MEDIA CENTER ============
   watchlistarr:
     container_name: watchlistarr
@@ -268,7 +298,44 @@ services:
       - ${USERDIR}/transmission/data:/data
     restart: unless-stopped
 
-  # ============ ERROR MONITORING ============
+  # ============ LIBRARY MAINTENANCE ============
+  # Cleans stalled/failed downloads out of Radarr/Sonarr queues. Skips any
+  # service whose API key is blank, so it's safe to leave keys empty on
+  # first boot and fill them in after the *arrs are running.
+  decluttarr:
+    container_name: decluttarr
+    image: ghcr.io/manimatter/decluttarr:latest
+    networks:
+      - download_network
+    environment:
+      - TZ=${TZ}
+      - LOG_LEVEL=INFO
+      - RADARR_URL=http://radarr:7878
+      - RADARR_KEY=${RADARR_API_KEY:-}
+      - SONARR_URL=http://sonarr:8989
+      - SONARR_KEY=${SONARR_API_KEY:-}
+      - REMOVE_TIMER=10
+      - REMOVE_FAILED=True
+      - REMOVE_STALLED=True
+      - REMOVE_MISSING_FILES=True
+      - REMOVE_ORPHANS=True
+    restart: unless-stopped
+
+  # Scans media files for codec / corruption issues. Web UI on :8585.
+  checkrr:
+    container_name: checkrr
+    image: ghcr.io/aetaric/checkrr:latest
+    networks:
+      - media_network
+    ports:
+      - "8585:8585"
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ${USERDIR}/checkrr/config:/etc/checkrr
+      - ${USERDIR}/plex/media:/media:ro
+    restart: unless-stopped
+
   cleanarr:
     container_name: cleanarr
     image: cleanarr/cleanarr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,9 +302,13 @@ services:
   # Cleans stalled/failed downloads out of Radarr/Sonarr queues. Skips any
   # service whose API key is blank, so it's safe to leave keys empty on
   # first boot and fill them in after the *arrs are running.
+  # Pinned to v1: v2 (Nov 2025) requires both base_url and api_key in
+  # structured RADARR/SONARR blocks, which breaks the blank-keys-on-first-boot
+  # workflow this service is configured around. Re-evaluate if v2 ever
+  # gains a "skip instances with empty api_key" behavior.
   decluttarr:
     container_name: decluttarr
-    image: ghcr.io/manimatter/decluttarr:latest
+    image: ghcr.io/manimatter/decluttarr:v1.50.2
     networks:
       - download_network
     environment:


### PR DESCRIPTION
## Summary

Adds four *arr-adjacent services from the running-containers screenshot in #37 that weren't yet in the repo:

| Service | Port | Network(s) | Purpose |
|---|---|---|---|
| **FlareSolverr** | `8191` | `media_network` | Cloudflare bypass proxy for Prowlarr indexers |
| **Maintainerr** | `6246` | `media_network` | Rule-based Plex library cleanup |
| **Decluttarr** | — | `download_network` | Removes stalled / failed downloads from \*arr queues |
| **Checkrr** | `8585` | `media_network` | Media file integrity scanner |

### Decluttarr — note on API keys

Decluttarr needs `RADARR_API_KEY` and `SONARR_API_KEY` from `.env` to actually do anything. Those keys come from the Radarr/Sonarr UIs **after** the stack is running, so:

- They're added to `.env.example` with a comment explaining the post-boot workflow.
- Decluttarr's container starts fine with both blank — it just skips any \*arr whose key isn't set.
- `CLAUDE.md`'s env-var contract gets a new third category ("Populated after first boot") so the chicken-and-egg is explicitly documented. This is the same confusion that came up in [discussion #4](https://github.com/joshdev8/AutoPlexx/discussions/4).

### Other touches

- The old `# ============ ERROR MONITORING ============` section header was a misnomer for cleanarr/requestrr. Renamed to `LIBRARY MAINTENANCE` and grouped the new decluttarr/checkrr/cleanarr together under it. (Requestrr is still in there for now — it doesn't fit either name perfectly.)
- README service table, network architecture lists, and CLAUDE.md network section all updated to reflect the four new services.

## Type of change

- [x] New service or feature (`feat/`)
- [x] Documentation (`docs/`)

## Validation

- [x] `docker compose config --quiet` passes locally with placeholder env values
- [x] CI's `compose-validate.yml` workflow exercises the exact path
- [x] Each new service is on the correct network(s) for its peers (FlareSolverr ↔ Prowlarr, Decluttarr ↔ *arrs over download_network, Maintainerr → Plex, Checkrr reading the media library)
- [ ] Started locally and confirmed each service comes up healthy (deferred — config edits only)

## Related

- Addresses part of #37 (running-containers audit)
- A follow-up PR will handle the monitoring side (Prometheus + cAdvisor + node-exporter), since #37's screenshot also shows those

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four media-management services: FlareSolverr, Maintainerr, Decluttarr, and Checkrr.

* **Documentation**
  * Updated architecture, network mappings, and service table to include the new services and roles.
  * Clarified env var behavior for Decluttarr: API keys are provided after first boot and omitted keys disable corresponding functionality.

* **Chores**
  * Added optional Decluttarr-related API key entries to the environment template.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joshdev8/AutoPlexx/pull/38)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->