### PR TITLE
Exempt pinned decluttarr from Watchtower auto-updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -323,6 +323,10 @@ services:
       - REMOVE_STALLED=True
       - REMOVE_MISSING_FILES=True
       - REMOVE_ORPHANS=True
+    labels:
+      # Tell Watchtower not to update this container — the pin above is
+      # intentional and v2 silently breaks on the v1 env var schema.
+      - "com.centurylinklabs.watchtower.enable=false"
     restart: unless-stopped
 
   # Scans media files for codec / corruption issues. Web UI on :8585.


### PR DESCRIPTION
## Summary

Adds the \`com.centurylinklabs.watchtower.enable=false\` label to the \`decluttarr\` service so Watchtower won't try to update it.

## Why

\`decluttarr\` is pinned to \`v1.50.2\` (see PR #38) because v2 (Nov 2025) replaced \`RADARR_URL\`/\`RADARR_KEY\`/\`SONARR_URL\`/\`SONARR_KEY\`/\`REMOVE_TIMER\`/\`REMOVE_FAILED\` with structured \`RADARR\`/\`SONARR\` blocks that mandate \`api_key\` — which breaks the blank-keys-on-first-boot workflow this service is configured around.

For an immutable tag like \`v1.50.2\`, Watchtower today won't actually do anything (it pulls by digest and \`v1.50.2\`'s digest is stable). The label is documentation of intent — a guard that survives a future re-tag, or someone changing this service to \`:latest\` without realising why the pin existed.

## Test plan

- [x] \`docker compose config\` validates and renders \`com.centurylinklabs.watchtower.enable: "false"\` on the decluttarr service
- [ ] Bring the stack up and confirm Watchtower's logs show decluttarr as skipped on its next scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration to prevent automatic updates to the application container.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joshdev8/AutoPlexx/pull/40)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->