### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -13,6 +13,9 @@ on:
       - '.env.example'
       - '.github/workflows/compose-validate.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/joshdev8/AutoPlexx/security/code-scanning/1](https://github.com/joshdev8/AutoPlexx/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/compose-validate.yml` at the workflow root so it applies to all jobs (currently just `validate`). For this workflow, the minimal required permission is:

- `contents: read`

Place it after the `on:` trigger section and before `jobs:`. This preserves existing behavior while documenting and enforcing least-privilege token access. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to enforce read-only access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->