### PR TITLE
Fix unavailable image references (#42)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,7 @@ services:
   # ============ MEDIA CENTER ============
   watchlistarr:
     container_name: watchlistarr
-    image: watchlistarr/watchlistarr
+    image: nylonee/watchlistarr
     networks:
       - download_network
     environment:
@@ -330,9 +330,12 @@ services:
     restart: unless-stopped
 
   # Scans media files for codec / corruption issues. Web UI on :8585.
+  # checkrr publishes no multi-arch tag — every tag is arch-suffixed, so there
+  # is no bare `latest`. amd64 hosts use `latest-amd64`; arm64 hosts must swap
+  # this to `latest-arm64v8`.
   checkrr:
     container_name: checkrr
-    image: ghcr.io/aetaric/checkrr:latest
+    image: ghcr.io/aetaric/checkrr:latest-amd64
     networks:
       - media_network
     ports:
@@ -346,7 +349,7 @@ services:
 
   cleanarr:
     container_name: cleanarr
-    image: cleanarr/cleanarr
+    image: selexin/cleanarr
     networks:
       - download_network
     environment:
@@ -357,7 +360,7 @@ services:
 
   requestrr:
     container_name: requestrr
-    image: requestrr/requestrr
+    image: thomst08/requestrr
     networks:
       - download_network
     ports:


### PR DESCRIPTION
## Problem

A fresh `docker compose up -d` fails because four services reference images that don't exist in any registry. `docker compose config` still passes (it only validates syntax/interpolation, not image availability), so the pre-flight check in the issue template gives a false green. Reported in #42.

## Verification

Checked each against its registry (Docker Hub public API / GHCR):

| Current (404 — never existed) | Fix (verified live) |
|---|---|
| `watchlistarr/watchlistarr` | `nylonee/watchlistarr` |
| `cleanarr/cleanarr` | `selexin/cleanarr` |
| `requestrr/requestrr` | `thomst08/requestrr` |
| `ghcr.io/aetaric/checkrr:latest` | `ghcr.io/aetaric/checkrr:latest-amd64` |

All three Docker Hub replacements have a `latest` tag, consistent with the untagged/`latest` convention the rest of the stack uses (so Watchtower keeps them current).

**checkrr note:** it publishes no multi-arch manifest — every tag is architecture-suffixed, which is the actual reason bare `:latest` 404s. Pinned to `latest-amd64` with a comment telling arm64 users to swap to `latest-arm64v8`.

## Testing

`docker compose config -q` parses OK and `config --images` now resolves all four to the corrected references.

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image sources for Watchlistarr, Cleanarr, and Requestrr.
  * Switched Checkrr to its AMD64-specific latest image tag.
  * Added documentation clarifying Checkrr image tagging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->