### PR TITLE
Document Seerr config directory ownership on first boot (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ A complete, opinionated [Plex Media Server](https://www.plex.tv/) stack delivere
 
 3. Set `USERDIR` in `.env` to the parent directory where configs and media should live. All services bind-mount under `${USERDIR}/<service>`, so this one variable controls where everything lands — you don't normally need to edit `docker-compose.yml` itself.
 
-4. Pre-create Seerr's config directory and give it to your `PUID:PGID`:
+4. Pre-create Seerr's config directory and give it to your `PUID:PGID`. Load the values from `.env` into your shell first so the paths expand correctly (or substitute the literal values from your `.env`):
 
     ```bash
+    set -a; source .env; set +a
     mkdir -p "${USERDIR}/docker/seerr/config"
     sudo chown -R "${PUID}:${PGID}" "${USERDIR}/docker/seerr/config"
     ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,16 @@ A complete, opinionated [Plex Media Server](https://www.plex.tv/) stack delivere
 
 3. Set `USERDIR` in `.env` to the parent directory where configs and media should live. All services bind-mount under `${USERDIR}/<service>`, so this one variable controls where everything lands — you don't normally need to edit `docker-compose.yml` itself.
 
-4. Start all services:
+4. Pre-create Seerr's config directory and give it to your `PUID:PGID`:
+
+    ```bash
+    mkdir -p "${USERDIR}/docker/seerr/config"
+    sudo chown -R "${PUID}:${PGID}" "${USERDIR}/docker/seerr/config"
+    ```
+
+    Unlike the `linuxserver` images (Radarr, Sonarr, etc.), the Seerr container runs as a fixed non-root `node` user and does **not** honor `PUID`/`PGID` — it can't fix ownership itself. If this directory doesn't already exist, Docker creates it as `root` on first boot and Seerr crashes with `EACCES: permission denied, mkdir '/app/config/logs/'`. Creating it up front owned by your user avoids that.
+
+5. Start all services:
 
     ```bash
     docker compose up -d


### PR DESCRIPTION
## Problem

On a fresh install, Seerr crashes immediately with:

```
Error: EACCES: permission denied, mkdir '/app/config/logs/'
```

Reported in #43.

## Root cause

The Seerr image (`ghcr.io/seerr-team/seerr`) runs as a **fixed non-root `node:node` user** with no entrypoint that manages permissions — it does **not** honor `PUID`/`PGID` the way the `linuxserver` images do (those run an s6 init as root that chowns `/config` on startup). When `${USERDIR}/docker/seerr/config` doesn't already exist, Docker creates the bind-mount source as `root:root` on first boot, so the `node` user can't write to it.

Adding `PUID`/`PGID` env vars would **not** fix this — the image ignores them. The directory has to be writable by the container's user before it starts.

## Fix

Docs-only. Add a first-boot step to pre-create the directory owned by the user's `PUID:PGID` before `docker compose up -d`, with an explanation of why Seerr differs from the linuxserver services. This matches the repo's existing "volume paths are user-specific" approach rather than changing compose.

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started instructions with a required Seerr configuration-directory setup step.
  * Added guidance for setting directory ownership to prevent permission-related startup failures.
  * Renumbered the subsequent service-startup step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->