### PR TITLE
Make checkrr architecture tag configurable via CHECKRR_IMAGE_TAG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,11 @@ TRANSMISSION_RPC_PASSWORD=
 # Host port to expose Grafana on. Defaults to 3000 if unset.
 GRAFANA_PORT=3000
 
+# ============ Checkrr ============
+# checkrr has no multi-arch image; every tag is architecture-suffixed.
+# Defaults to latest-amd64. On arm64 hosts, set this to latest-arm64v8.
+CHECKRR_IMAGE_TAG=latest-amd64
+
 # ============ Decluttarr (queue cleanup for Radarr/Sonarr) ============
 # These keys come from Radarr's Settings -> General -> API Key (and Sonarr's
 # equivalent) AFTER the stack is running. Decluttarr starts fine with them

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -331,11 +331,11 @@ services:
 
   # Scans media files for codec / corruption issues. Web UI on :8585.
   # checkrr publishes no multi-arch tag — every tag is arch-suffixed, so there
-  # is no bare `latest`. amd64 hosts use `latest-amd64`; arm64 hosts must swap
-  # this to `latest-arm64v8`.
+  # is no bare `latest`. Defaults to amd64; arm64 hosts set
+  # CHECKRR_IMAGE_TAG=latest-arm64v8 in .env instead of editing this file.
   checkrr:
     container_name: checkrr
-    image: ghcr.io/aetaric/checkrr:latest-amd64
+    image: ghcr.io/aetaric/checkrr:${CHECKRR_IMAGE_TAG:-latest-amd64}
     networks:
       - media_network
     ports:


### PR DESCRIPTION
## Context

Follow-up to a CodeRabbit nitpick on #44: checkrr's tag was hard-coded to `latest-amd64` (checkrr publishes no multi-arch image), so arm64 users had to edit the tracked `docker-compose.yml` before `docker compose up -d` would work.

## Change

Make the tag an env override with the amd64 tag as the default:

```yaml
image: ghcr.io/aetaric/checkrr:${CHECKRR_IMAGE_TAG:-latest-amd64}
```

This matches the `${VAR:-default}` pattern already used for `GRAFANA_PORT` and `LOCAL_NETWORK`. Added `CHECKRR_IMAGE_TAG=latest-amd64` to `.env.example` with a note that arm64 hosts set it to `latest-arm64v8`. **Default behavior is unchanged** — amd64 users need to do nothing.

## Testing

`docker compose config --images` verified in three cases:
- default (`.env.example` value) → `latest-amd64`
- `CHECKRR_IMAGE_TAG=latest-arm64v8` → `latest-arm64v8`
- var removed entirely → falls back to `latest-amd64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)