### PR TITLE
Add release badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <div align="center">
 
+[![Release](https://img.shields.io/github/v/release/joshdev8/AutoPlexx?style=flat-square)](https://github.com/joshdev8/AutoPlexx/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/joshdev8/AutoPlexx?style=flat-square)](https://github.com/joshdev8/AutoPlexx/stargazers)
 [![Last commit](https://img.shields.io/github/last-commit/joshdev8/AutoPlexx?style=flat-square)](https://github.com/joshdev8/AutoPlexx/commits/main)


### PR DESCRIPTION
The README had no project version/release reference. This adds a dynamic [shields.io](https://shields.io) release badge to the badge row:

```markdown
[![Release](https://img.shields.io/github/v/release/joshdev8/AutoPlexx?style=flat-square)](https://github.com/joshdev8/AutoPlexx/releases/latest)
```

It reads the latest GitHub release via the API, so it currently shows **v2.0.1** and updates itself on every future release — no manual version edits needed. Verified it resolves to `v2.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)