### PR TITLE
Add header search, Seerr request link, and alert bell (phase 3)

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -84,6 +84,16 @@ fixes the problem. See `hintFor()` in `sources/transmission.ts` — an auth
 failure and an unreachable host need different advice, and a generic hint sends
 people looking in the wrong place.
 
+## The header
+
+Three controls, all reading data the app already polls:
+
+- **Search** (`components/CommandSearch.tsx`) filters the service catalog and opens the one you pick. Focus it with `/` or `Ctrl`/`Cmd`+`K`. Only services with a published port are offered as results, since opening one is the only thing a result does — services without a web UI are named in a footer line instead of appearing as rows that do nothing on Enter.
+- **Request** deep-links to Seerr rather than posting a request. The dashboard is read-only and ships no auth, so a request endpoint here would let anyone who can reach the page add to the library under Seerr's credentials with no record of who did it. Seerr already has accounts and approval rules.
+- **Alerts** (`components/Notifications.tsx`) is derived in the browser by `alerts.ts` from `/api/health` plus `/api/integrations` — both already on screen, so a dedicated endpoint would re-poll the same sources to produce something the client can assemble for free.
+
+Two states deliberately don't raise an alert: `absent` services (a user who trimmed services out of their compose file shouldn't get permanent alerts for things they chose not to run) and `waiting` integrations (the normal state on a clean install — alerting would mean a first boot opens with a full inbox that clears itself). When the socket proxy is unreachable, every service reads `absent`, so that case short-circuits to a single alert naming the proxy rather than reporting nothing at all.
+
 ## Conventions
 
 - **Nothing may throw on missing configuration.** An unset key or an unreachable upstream degrades that one panel; it never blanks the page.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -80,7 +80,7 @@ Every variable has a working default — the app must start and be useful agains
    which handles the loading, unavailable and empty cases for you.
 
 The `hint` is the part that matters: it should name the one concrete step that
-fixes the problem. See `hintFor()` in `sources/transmission.ts` — an auth
+fixes the problem. See `hintFor()` in `server/src/sources/transmission.ts` — an auth
 failure and an unreachable host need different advice, and a generic hint sends
 people looking in the wrong place.
 

--- a/dashboard/web/src/alerts.ts
+++ b/dashboard/web/src/alerts.ts
@@ -1,0 +1,98 @@
+/**
+ * Derives the "what needs attention" list from data the app already polls.
+ *
+ * This is computed in the browser rather than served from the API because both
+ * inputs are already on screen — /api/health drives the sidebar and the health
+ * tile, /api/integrations drives Setup. A dedicated endpoint would poll the
+ * same two sources again to produce something the client can assemble for free.
+ */
+
+import type { HealthReport, Integration, ServiceStatus } from './types';
+
+export type AlertKind = 'unreachable' | 'attn' | 'down' | 'blocked';
+
+export interface Alert {
+  id: string;
+  kind: AlertKind;
+  title: string;
+  /** One line naming what is actually wrong, or the step that fixes it. */
+  detail: string;
+  /** Set when the alert is about a service with a web UI, so it can be opened. */
+  port?: number;
+}
+
+/**
+ * Rendering order. A stack that can't be inspected at all outranks a single
+ * unhealthy container, which outranks a stopped one (often deliberate), which
+ * outranks an integration that only degrades one panel.
+ */
+const ORDER: Record<AlertKind, number> = {
+  unreachable: 0,
+  attn: 1,
+  down: 2,
+  blocked: 3,
+};
+
+export function deriveAlerts(
+  health: HealthReport | null,
+  integrations: Integration[],
+): Alert[] {
+  const alerts: Alert[] = [];
+
+  // Without the socket proxy every service reports `absent`, which would
+  // otherwise produce no alerts at all — the quietest possible rendering of the
+  // loudest possible problem. Report the cause and stop: the per-service states
+  // behind it aren't trustworthy.
+  if (health && !health.reachable) {
+    return [
+      {
+        id: 'docker-unreachable',
+        kind: 'unreachable',
+        title: 'Container state unavailable',
+        detail:
+          'The dashboard cannot reach docker-socket-proxy, so service status may be stale. Check that the autoplexx-socket-proxy container is running.',
+      },
+    ];
+  }
+
+  for (const service of health?.services ?? []) {
+    // `absent` is not a fault. A user who trimmed services out of their compose
+    // file would otherwise get a permanent list of alerts for things they chose
+    // not to run.
+    if (service.state === 'attn') {
+      alerts.push(serviceAlert(service, 'attn', 'needs attention'));
+    } else if (service.state === 'down') {
+      alerts.push(serviceAlert(service, 'down', 'is stopped'));
+    }
+  }
+
+  for (const integration of integrations) {
+    // Only `blocked` — `waiting` is the normal state on a clean install, where
+    // a service simply hasn't written its config file yet. Alerting on it would
+    // mean a first boot opens with a full inbox that clears itself.
+    if (integration.state !== 'blocked') continue;
+
+    const service = health?.services.find((candidate) => candidate.id === integration.source);
+    alerts.push({
+      id: `integration:${integration.source}`,
+      kind: 'blocked',
+      title: `${service?.name ?? integration.source} is not connected`,
+      detail: integration.hint ?? 'The dashboard could not read an API key for this service.',
+      ...(service?.port != null ? { port: service.port } : {}),
+    });
+  }
+
+  return alerts.sort((a, b) => ORDER[a.kind] - ORDER[b.kind]);
+}
+
+function serviceAlert(service: ServiceStatus, kind: AlertKind, summary: string): Alert {
+  return {
+    id: `service:${service.id}`,
+    kind,
+    title: `${service.name} ${summary}`,
+    // Docker's own status line is the most specific thing available here —
+    // "Restarting (1) 4 seconds ago" says far more than "needs attention".
+    detail: service.status ?? service.blurb,
+    ...(service.port != null ? { port: service.port } : {}),
+  };
+}

--- a/dashboard/web/src/app/App.tsx
+++ b/dashboard/web/src/app/App.tsx
@@ -10,7 +10,8 @@ import { StackHealth } from '../components/StackHealth';
 import { Gauges } from '../components/Gauges';
 import { usePolled } from '../hooks/usePolled';
 import { useTheme } from '../hooks/useTheme';
-import type { Gauge, HealthReport, Result, ServiceGroup, VpnStatus } from '../types';
+import { deriveAlerts } from '../alerts';
+import type { Gauge, HealthReport, Integration, Result, ServiceGroup, VpnStatus } from '../types';
 
 interface ServicesResponse {
   groups: readonly { id: ServiceGroup; label: string }[];
@@ -20,6 +21,8 @@ interface ServicesResponse {
 type View = 'command' | 'launcher' | 'setup';
 
 const HEALTH_POLL_MS = 10_000;
+/** Matches the server's discovery TTL, so a newly written key surfaces promptly. */
+const INTEGRATION_POLL_MS = 30_000;
 
 export function App() {
   const [theme, toggleTheme] = useTheme();
@@ -31,9 +34,20 @@ export function App() {
   const health = usePolled<HealthReport>('/api/health', HEALTH_POLL_MS);
   const metrics = usePolled<Result<{ gauges: Gauge[] }>>('/api/metrics', 15_000);
   const vpn = usePolled<Result<VpnStatus>>('/api/vpn', 30_000);
+  // Polled here rather than inside Setup because the alert bell needs the same
+  // data — one poll feeds both, whichever view is on screen.
+  const integrations = usePolled<{ integrations: Integration[] }>(
+    '/api/integrations',
+    INTEGRATION_POLL_MS,
+  );
 
   const groups = catalog.data?.groups ?? [];
   const services = health.data?.services ?? catalog.data?.services ?? [];
+
+  const alerts = useMemo(
+    () => deriveAlerts(health.data, integrations.data?.integrations ?? []),
+    [health.data, integrations.data],
+  );
 
   const subtitle = useMemo(() => {
     const today = new Date().toLocaleDateString(undefined, {
@@ -64,7 +78,16 @@ export function App() {
       <Sidebar services={services} groups={groups} vpn={vpn.data} vpnLoading={vpn.loading} />
 
       <main style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
-        <Header title="Dashboard" subtitle={subtitle} theme={theme} onToggleTheme={toggleTheme} />
+        <Header
+          title="Dashboard"
+          subtitle={subtitle}
+          theme={theme}
+          onToggleTheme={toggleTheme}
+          services={services}
+          groups={groups}
+          alerts={alerts}
+          onOpenSetup={() => setView('setup')}
+        />
 
         <div style={{ padding: 'var(--space-8)', flex: 1 }} className="ap-view">
           <div className="seg" style={{ marginBottom: 'var(--space-6)' }}>
@@ -146,7 +169,9 @@ export function App() {
             ) : (
               <Launcher services={services} groups={groups} />
             ))}
-          {view === 'setup' && <Setup />}
+          {view === 'setup' && (
+            <Setup integrations={integrations.data?.integrations ?? []} loading={integrations.loading} />
+          )}
         </div>
       </main>
     </div>

--- a/dashboard/web/src/app/Header.tsx
+++ b/dashboard/web/src/app/Header.tsx
@@ -1,5 +1,9 @@
-import { Moon, Sun } from '@phosphor-icons/react';
+import { ArrowUpRight, Moon, Plus, Sun } from '@phosphor-icons/react';
 
+import { CommandSearch } from '../components/CommandSearch';
+import { Notifications } from '../components/Notifications';
+import { serviceUrl, type ServiceGroup, type ServiceStatus } from '../types';
+import type { Alert } from '../alerts';
 import type { Theme } from '../hooks/useTheme';
 
 interface Props {
@@ -7,9 +11,22 @@ interface Props {
   subtitle: string;
   theme: Theme;
   onToggleTheme: () => void;
+  services: ServiceStatus[];
+  groups: readonly { id: ServiceGroup; label: string }[];
+  alerts: Alert[];
+  onOpenSetup: () => void;
 }
 
-export function Header({ title, subtitle, theme, onToggleTheme }: Props) {
+export function Header({
+  title,
+  subtitle,
+  theme,
+  onToggleTheme,
+  services,
+  groups,
+  alerts,
+  onOpenSetup,
+}: Props) {
   return (
     <header
       style={{
@@ -24,13 +41,32 @@ export function Header({ title, subtitle, theme, onToggleTheme }: Props) {
         background: 'var(--color-bg)',
       }}
     >
-      <div style={{ minWidth: 0 }}>
+      {/*
+        The title yields space before the controls do. Without this the search
+        box is the thing that collapses on a narrow window, and a search field
+        squeezed down to its own icon is worse than a truncated date.
+      */}
+      <div style={{ minWidth: 0, flex: '0 1 auto', overflow: 'hidden' }}>
         <h4 style={{ margin: 0, fontSize: 21 }}>{title}</h4>
-        <div className="text-muted" style={{ fontSize: 12, marginTop: 2 }}>
+        <div
+          className="text-muted"
+          style={{
+            fontSize: 12,
+            marginTop: 2,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
           {subtitle}
         </div>
       </div>
-      <div style={{ flex: 1 }} />
+      <div style={{ flex: '1 0 var(--space-4)' }} />
+
+      <CommandSearch services={services} groups={groups} />
+      <RequestButton services={services} />
+      <Notifications alerts={alerts} onOpenSetup={onOpenSetup} />
+
       <button
         type="button"
         className="btn btn-secondary btn-icon"
@@ -40,5 +76,46 @@ export function Header({ title, subtitle, theme, onToggleTheme }: Props) {
         {theme === 'dark' ? <Moon size={17} weight="regular" /> : <Sun size={17} weight="regular" />}
       </button>
     </header>
+  );
+}
+
+/**
+ * Hands off to Seerr rather than requesting from here.
+ *
+ * The design mocked a Request control in the header, and this is that control —
+ * but it deep-links instead of posting. The dashboard is read-only and ships no
+ * auth, so a request endpoint here would let anyone who can reach the LAN page
+ * add to the library under Seerr's credentials, with no record of who did it.
+ * Seerr already has accounts, approval rules and its own search; what the
+ * header adds is the shortcut, not a second front door.
+ */
+function RequestButton({ services }: { services: ServiceStatus[] }) {
+  const seerr = services.find((service) => service.id === 'seerr');
+
+  // Not in the catalog, absent from the host, or published without a UI port —
+  // in each case there is nothing to link to, so no control is shown.
+  if (!seerr || seerr.state === 'absent' || seerr.port === null) return null;
+
+  if (seerr.state === 'down') {
+    return (
+      <button type="button" className="btn btn-secondary" disabled title="Seerr is not running">
+        <Plus size={15} weight="regular" />
+        Request
+      </button>
+    );
+  }
+
+  return (
+    <a
+      className="btn btn-primary"
+      href={serviceUrl(seerr.port)}
+      target="_blank"
+      rel="noreferrer"
+      title="Request a movie or series in Seerr"
+    >
+      <Plus size={15} weight="regular" />
+      Request
+      <ArrowUpRight size={12} weight="regular" />
+    </a>
   );
 }

--- a/dashboard/web/src/components/CommandSearch.tsx
+++ b/dashboard/web/src/components/CommandSearch.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { MagnifyingGlass } from '@phosphor-icons/react';
+
+import { ServiceIcon } from './ServiceIcon';
+import { StatusDot } from './StatusDot';
+import { useDismissable } from '../hooks/useDismissable';
+import { serviceUrl, type ServiceGroup, type ServiceStatus } from '../types';
+
+interface Props {
+  services: ServiceStatus[];
+  groups: readonly { id: ServiceGroup; label: string }[];
+}
+
+const MAX_RESULTS = 7;
+
+/** A service is openable when it publishes a web UI. */
+interface Openable extends ServiceStatus {
+  port: number;
+}
+
+export interface Matches {
+  /** Services that can actually be opened — the navigable results. */
+  openable: Openable[];
+  /** Matched services with no web UI, named but not offered as results. */
+  uiless: ServiceStatus[];
+}
+
+/**
+ * Ranks a service against a query. Lower is better; `null` means no match.
+ *
+ * Name matches beat blurb matches, and a name that starts with the query beats
+ * one that merely contains it — typing "so" should reach Sonarr before
+ * Flaresolverr.
+ */
+export function score(service: ServiceStatus, query: string): number | null {
+  const name = service.name.toLowerCase();
+  if (name.startsWith(query)) return 0;
+  if (name.includes(query)) return 1;
+  if (service.id.includes(query)) return 2;
+  if (service.blurb.toLowerCase().includes(query)) return 3;
+  return null;
+}
+
+/**
+ * Filters the catalog for the search menu.
+ *
+ * Only services in a visible group are searchable, matching what the sidebar
+ * and Launcher show — `system` services like the socket proxy have no UI and
+ * aren't things a user navigates to.
+ */
+export function match(
+  services: ServiceStatus[],
+  groups: readonly { id: ServiceGroup }[],
+  rawQuery: string,
+): Matches {
+  const query = rawQuery.trim().toLowerCase();
+  if (query === '') return { openable: [], uiless: [] };
+
+  const visible = new Set(groups.map((group) => group.id));
+  const ranked = services
+    .filter((service) => visible.has(service.group))
+    .flatMap((service) => {
+      const rank = score(service, query);
+      return rank === null ? [] : [{ service, rank }];
+    })
+    .sort((a, b) => a.rank - b.rank || a.service.name.localeCompare(b.service.name));
+
+  return {
+    openable: ranked
+      .flatMap(({ service }) => (service.port === null ? [] : [{ ...service, port: service.port }]))
+      .slice(0, MAX_RESULTS),
+    uiless: ranked.flatMap(({ service }) => (service.port === null ? [service] : [])),
+  };
+}
+
+/**
+ * The header's service search.
+ *
+ * The one action a result can take is "open this service", so services without
+ * a web UI aren't offered as results — they'd be rows that do nothing on Enter.
+ * They're still named underneath when they match, because a user searching
+ * "watchtower" deserves better than an empty menu.
+ */
+export function CommandSearch({ services, groups }: Props) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listId = useId();
+
+  const close = () => setOpen(false);
+  const wrapRef = useDismissable<HTMLDivElement>(open, close);
+
+  const { openable, uiless } = useMemo(() => match(services, groups, query), [services, groups, query]);
+
+  // Clamp rather than reset, so results narrowing under the cursor doesn't
+  // leave the highlight pointing past the end of the list.
+  const activeIndex = Math.min(active, Math.max(openable.length - 1, 0));
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const typing =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target?.isContentEditable === true;
+
+      // "/" is the convention for search-focus, but only when it isn't being
+      // typed into something.
+      const slash = event.key === '/' && !typing;
+      const commandK = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
+      if (!slash && !commandK) return;
+
+      event.preventDefault();
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  const openService = (service: Openable) => {
+    window.open(serviceUrl(service.port), '_blank', 'noopener,noreferrer');
+    setQuery('');
+    close();
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      // First Escape closes the menu, a second clears the box — so an
+      // accidental open doesn't cost the query.
+      if (open) close();
+      else setQuery('');
+      return;
+    }
+    if (event.key === 'Tab') {
+      close();
+      return;
+    }
+    if (openable.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setOpen(true);
+      setActive((index) => (Math.min(index, openable.length - 1) + 1) % openable.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setOpen(true);
+      setActive((index) => (Math.min(index, openable.length - 1) + openable.length - 1) % openable.length);
+    } else if (event.key === 'Enter') {
+      const service = openable[activeIndex];
+      if (service) openService(service);
+    }
+  };
+
+  const expanded = open && query.trim() !== '';
+
+  return (
+    <div ref={wrapRef} style={{ position: 'relative', flex: '1 1 auto', minWidth: 150, maxWidth: 360 }}>
+      <MagnifyingGlass
+        size={15}
+        weight="regular"
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: 10,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          color: 'var(--color-neutral-500)',
+          pointerEvents: 'none',
+        }}
+      />
+      <input
+        ref={inputRef}
+        className="input"
+        type="text"
+        role="combobox"
+        aria-expanded={expanded}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        aria-activedescendant={
+          expanded && openable[activeIndex] ? `${listId}-${openable[activeIndex].id}` : undefined
+        }
+        aria-label="Search services"
+        placeholder="Search services…"
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setActive(0);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+        style={{ width: '100%', paddingLeft: 32, height: 36 }}
+      />
+
+      {expanded && (
+        <div className="ap-pop elev-lg" style={{ top: 'calc(100% + 6px)', left: 0, right: 0 }}>
+          <ul id={listId} role="listbox" aria-label="Service results" className="ap-menu">
+            {openable.map((service, index) => (
+              <li
+                key={service.id}
+                id={`${listId}-${service.id}`}
+                role="option"
+                aria-selected={index === activeIndex}
+                className="ap-menu-item"
+                // Keeps focus in the input so the combobox keeps its keyboard
+                // contract; the press is handled on mouseDown instead of click.
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  openService(service);
+                }}
+                onMouseEnter={() => setActive(index)}
+              >
+                <ServiceIcon mono={service.mono} hue={service.hue} />
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span style={{ display: 'block', fontSize: 14 }}>{service.name}</span>
+                  <span className="text-muted" style={{ display: 'block', fontSize: 11 }}>
+                    {service.blurb} · :{service.port}
+                  </span>
+                </span>
+                <StatusDot state={service.state} size={7} detail={service.status} />
+              </li>
+            ))}
+
+            {openable.length === 0 && (
+              <li className="text-muted" style={{ padding: 'var(--space-3)', fontSize: 13 }}>
+                No matching service
+              </li>
+            )}
+          </ul>
+
+          {uiless.length > 0 && (
+            <div
+              className="text-muted"
+              style={{
+                borderTop: '1px solid var(--color-divider)',
+                padding: 'var(--space-2) var(--space-3)',
+                fontSize: 11,
+              }}
+            >
+              Also matched, no web UI: {uiless.map((service) => service.name).join(', ')}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/web/src/components/Notifications.tsx
+++ b/dashboard/web/src/components/Notifications.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { ArrowUpRight, Bell, CheckCircle, PlugsConnected, Warning, WarningOctagon } from '@phosphor-icons/react';
+
+import { useDismissable } from '../hooks/useDismissable';
+import { serviceUrl } from '../types';
+import type { Alert, AlertKind } from '../alerts';
+
+interface Props {
+  alerts: Alert[];
+  /** Jumps to the Setup view, where a blocked integration is explained in full. */
+  onOpenSetup: () => void;
+}
+
+const KIND = {
+  unreachable: { Icon: WarningOctagon, hue: 'var(--ap-red)' },
+  attn: { Icon: Warning, hue: 'var(--ap-amber)' },
+  down: { Icon: WarningOctagon, hue: 'var(--ap-red)' },
+  blocked: { Icon: PlugsConnected, hue: 'var(--ap-amber)' },
+} as const satisfies Record<AlertKind, { Icon: typeof Warning; hue: string }>;
+
+/**
+ * The header's alert bell.
+ *
+ * Everything here is derived from data already on screen, so it never
+ * contradicts the sidebar — and it deliberately says nothing when nothing is
+ * wrong, rather than inventing an activity feed. The Command Center's Activity
+ * panel is where "things that happened" belongs; this is only "things that need
+ * you".
+ */
+export function Notifications({ alerts, onOpenSetup }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useDismissable<HTMLDivElement>(open, () => setOpen(false));
+
+  const count = alerts.length;
+  const label = count === 0 ? 'Alerts: nothing needs attention' : `Alerts: ${count} need attention`;
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        className="btn btn-secondary btn-icon"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={label}
+        title={label}
+        onClick={() => setOpen((wasOpen) => !wasOpen)}
+        style={{ position: 'relative' }}
+      >
+        <Bell size={17} weight="regular" />
+        {count > 0 && (
+          <span className="ap-badge" aria-hidden="true">
+            {count > 9 ? '9+' : count}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          className="ap-pop elev-lg"
+          role="dialog"
+          aria-label="Alerts"
+          style={{ top: 'calc(100% + 8px)', right: 0, width: 340 }}
+        >
+          <div
+            style={{
+              padding: 'var(--space-3)',
+              borderBottom: '1px solid var(--color-divider)',
+              fontFamily: 'var(--font-heading)',
+              fontWeight: 500,
+              fontSize: 13,
+            }}
+          >
+            Needs attention
+          </div>
+
+          {count === 0 ? (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--space-3)',
+                padding: 'var(--space-4) var(--space-3)',
+                fontSize: 13,
+              }}
+            >
+              <CheckCircle size={18} color="var(--ap-green)" weight="regular" />
+              <span className="text-muted">Every service is running and connected.</span>
+            </div>
+          ) : (
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0, maxHeight: 340, overflowY: 'auto' }}>
+              {alerts.map((alert) => (
+                <AlertRow
+                  key={alert.id}
+                  alert={alert}
+                  onOpenSetup={() => {
+                    setOpen(false);
+                    onOpenSetup();
+                  }}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AlertRow({ alert, onOpenSetup }: { alert: Alert; onOpenSetup: () => void }) {
+  const { Icon, hue } = KIND[alert.kind];
+
+  return (
+    <li
+      style={{
+        display: 'flex',
+        gap: 'var(--space-3)',
+        padding: 'var(--space-3)',
+        borderBottom: '1px solid var(--color-divider)',
+      }}
+    >
+      <Icon size={16} color={hue} weight="regular" style={{ flex: 'none', marginTop: 2 }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13 }}>{alert.title}</div>
+        <div className="text-muted" style={{ fontSize: 11, marginTop: 2, lineHeight: 1.5 }}>
+          {alert.detail}
+        </div>
+        <div style={{ display: 'flex', gap: 'var(--space-3)', marginTop: 'var(--space-2)' }}>
+          {/*
+            A stopped container's UI won't answer, so "Open" is only offered for
+            problems where the service is still up — a blocked integration is
+            exactly that case.
+          */}
+          {alert.kind === 'blocked' && (
+            <>
+              <button type="button" className="btn btn-ghost" style={{ fontSize: 12 }} onClick={onOpenSetup}>
+                Setup
+              </button>
+              {alert.port != null && (
+                <a
+                  className="btn btn-ghost"
+                  href={serviceUrl(alert.port)}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ fontSize: 12 }}
+                >
+                  Open
+                  <ArrowUpRight size={12} weight="regular" />
+                </a>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/dashboard/web/src/hooks/useDismissable.ts
+++ b/dashboard/web/src/hooks/useDismissable.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Closes an open popover on Escape or on a pointer press outside it, and
+ * returns the ref to put on the popover's container.
+ *
+ * Uses `pointerdown` rather than `click` so a press that starts outside closes
+ * immediately, and listens in the capture phase so a press on a control that
+ * stops propagation still dismisses.
+ */
+export function useDismissable<T extends HTMLElement>(open: boolean, onDismiss: () => void) {
+  const ref = useRef<T>(null);
+  // Kept in a ref so a caller passing an inline arrow doesn't re-subscribe on
+  // every render.
+  const dismiss = useRef(onDismiss);
+  dismiss.current = onDismiss;
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onPointerDown = (event: PointerEvent) => {
+      const node = ref.current;
+      if (node && event.target instanceof Node && !node.contains(event.target)) {
+        dismiss.current();
+      }
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') dismiss.current();
+    };
+
+    document.addEventListener('pointerdown', onPointerDown, true);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  return ref;
+}

--- a/dashboard/web/src/styles/autoplexx.css
+++ b/dashboard/web/src/styles/autoplexx.css
@@ -18,6 +18,14 @@
   --ap-cyan-dim: oklch(48% 0.09 220);
   --ap-violet: var(--color-accent-400);
   --ap-violet-dim: var(--color-accent-700);
+
+  /*
+   * The alert badge is the one place amber sits behind text rather than being
+   * used as a dot, border or bar, so it needs its own value: the light theme's
+   * --ap-amber carries only 3.4:1 against --color-bg, under the 4.5:1 AA asks
+   * for at 10px. Dark theme already clears it at 9.9:1 and reuses amber as-is.
+   */
+  --ap-badge: var(--ap-amber);
 }
 
 [data-theme='light'] {
@@ -29,6 +37,8 @@
   --ap-amber: oklch(62% 0.15 78);
   --ap-red: oklch(56% 0.19 22);
   --ap-cyan: oklch(58% 0.13 230);
+  /* 5.1:1 against --color-bg, where plain --ap-amber manages only 3.4:1. */
+  --ap-badge: oklch(52% 0.15 78);
 }
 
 @keyframes ap-fade {
@@ -107,20 +117,29 @@
   background: color-mix(in srgb, var(--color-accent) 14%, transparent);
 }
 
-/* The unread count on the alert bell. */
+/*
+ * The unread count on the alert bell.
+ *
+ * nocturne's spacing scale is a layout scale — 2.8 / 5.6 / 8.4 / 11.2px — and
+ * none of its steps reach the 16px an icon-corner badge needs. So the size is
+ * stated once here and the offset, radius and line-height derive from it,
+ * rather than being four independent numbers that have to stay in agreement.
+ */
 .ap-badge {
+  --badge-size: 16px;
+
   position: absolute;
-  top: -4px;
-  right: -4px;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
-  border-radius: 8px;
-  background: var(--ap-amber);
+  top: calc(var(--badge-size) / -4);
+  right: calc(var(--badge-size) / -4);
+  min-width: var(--badge-size);
+  height: var(--badge-size);
+  padding: 0 var(--space-1);
+  border-radius: calc(var(--badge-size) / 2);
+  background: var(--ap-badge);
   color: var(--color-bg);
   font-size: 10px;
   font-weight: 600;
-  line-height: 16px;
+  line-height: var(--badge-size);
   text-align: center;
 }
 

--- a/dashboard/web/src/styles/autoplexx.css
+++ b/dashboard/web/src/styles/autoplexx.css
@@ -67,6 +67,63 @@
   box-shadow: var(--shadow-md);
 }
 
+/*
+ * Header popovers — the search menu and the alert list.
+ *
+ * z-index sits above the sticky header's own stacking context (20) so a menu
+ * opened from the header isn't clipped by the content below it.
+ */
+.ap-pop {
+  position: absolute;
+  z-index: 30;
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.ap-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.ap-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+}
+
+/*
+ * Keyboard and pointer highlight are the same state: the pointer sets the
+ * active index rather than styling itself, so the two can never disagree about
+ * which row Enter will open.
+ */
+.ap-menu-item[aria-selected='true'] {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+}
+
+/* The unread count on the alert bell. */
+.ap-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--ap-amber);
+  color: var(--color-bg);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  text-align: center;
+}
+
 /* Tinted tags and dots driven by a `--h` hue custom property. */
 .ap-tag {
   display: inline-flex;

--- a/dashboard/web/src/views/Setup.tsx
+++ b/dashboard/web/src/views/Setup.tsx
@@ -1,7 +1,12 @@
 import { CheckCircle, Clock, Warning } from '@phosphor-icons/react';
 
-import { usePolled } from '../hooks/usePolled';
 import type { Integration } from '../types';
+
+interface Props {
+  integrations: Integration[];
+  /** True only until the first response — a refresh never blanks the list. */
+  loading: boolean;
+}
 
 const LABEL: Record<string, string> = {
   sonarr: 'Sonarr',
@@ -25,13 +30,11 @@ const STATE = {
  * this panel exists to make that legible: on a first boot the user can watch
  * integrations connect themselves, and anything genuinely stuck names the one
  * step that fixes it. Keys are never sent to the browser — only their state.
+ *
+ * The data is polled by App and passed in, because the header's alert bell
+ * reads the same endpoint and one poll should serve both.
  */
-export function Setup() {
-  // Polled on the same cadence as server-side discovery, so a service that has
-  // just written its config shows up here without a reload.
-  const { data, loading } = usePolled<{ integrations: Integration[] }>('/api/integrations', 30_000);
-
-  const integrations = data?.integrations ?? [];
+export function Setup({ integrations, loading }: Props) {
   const live = integrations.filter((i) => i.state === 'live').length;
 
   return (
@@ -50,7 +53,7 @@ export function Setup() {
         )}
       </div>
 
-      {loading && !data ? (
+      {loading && integrations.length === 0 ? (
         <span className="text-muted" style={{ fontSize: 13 }}>
           Loading…
         </span>


### PR DESCRIPTION
Phase 3 of the dashboard from #48: the header controls that #49 deliberately shipped as empty space, because they'd have been dead until phase 2's data landed.

**Based on `feat/dashboard-widgets` (#50)** — review that one first; this PR retargets to `main` once it merges.

## The three controls

| Control | What it does | Why it's built this way |
|---|---|---|
| **Search** | Filters the service catalog, opens what you pick. `/` or `Ctrl`/`Cmd`+`K` to focus | Only services with a published port are offered as results — opening one is all a result does. Matches with no web UI are named in a footer line instead of becoming rows that do nothing on Enter |
| **Request** | Deep-links to Seerr | The dashboard is read-only and ships no auth. A request endpoint here would let anyone who can reach the LAN page add to the library under Seerr's credentials, with no record of who did it. Seerr already has accounts and approval rules |
| **Alerts** | What needs attention, from container state + integrations | Derived in the browser from data already on screen, so no new endpoint re-polls the same two sources to produce what the client can assemble for free |

The avatar from the design stays out — there's no auth for it to represent.

## What deliberately doesn't raise an alert

- **`absent` services.** A user who trimmed services out of their compose file would otherwise get a permanent list of alerts for things they chose not to run.
- **`waiting` integrations.** That's the *normal* state on a clean install, where a service simply hasn't written its config file yet. Alerting would mean a first boot opens with a full inbox that clears itself.
- **An unreachable socket proxy** makes every service read `absent`, which would render the loudest possible problem as total silence. That case short-circuits to a single alert naming the proxy.

## Also here

- The integrations poll moves up to `App` — the bell and Setup now share one request instead of each running their own.
- The header title truncates before the controls shrink. Without it the search box was the thing that collapsed on a narrow window, down to just its own icon.

## Verification

Driven in a browser against the live stack (18/18 up), not just built:

- Search ranking confirmed: `so` returns Sonarr (name prefix) ahead of cAdvisor and FlareSolverr, with `aria-activedescendant` tracking the highlight
- `watch` returns no openable rows and correctly reports "Also matched, no web UI: Watchlistarr" — Watchtower, a `system` service, stays out of search entirely
- Bell reads "nothing needs attention" on the healthy stack, with all six integrations `waiting` — confirming waiting is not an alert
- With container state doctored to an unhealthy Radarr, a stopped Tautulli and a blocked Seerr: 3 alerts, ordered attn → down → blocked, each carrying Docker's own status line ("Exited (137) 2 minutes ago") rather than a generic label
- The blocked alert's **Setup** action closes the popover, switches views, and lands on the matching integration row with its hint
- Header verified at 1440px and at 900px, where the subtitle ellipsizes and the search stays usable
- `typecheck`, `lint`, 40 tests and `build` all clean

## Note for review

`web/` still has no test runner, so `alerts.ts` and the search ranking in `CommandSearch.tsx` are verified in the browser rather than by unit test, despite both being pure functions written to be testable. Adding one is web infrastructure rather than a feature, so it belongs with the responsive pass rather than in here — happy to do it either way.

Refs #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added header search for quickly finding and opening services.
  * Added a Request button that links to Seerr when available.
  * Added an Alerts menu showing service and integration issues, with setup and open actions.
  * Added a Setup view displaying integration connection status, hints, and configuration sources.
  * Added dashboard views for command center, launcher, and setup, with live metrics and VPN status.

* **Documentation**
  * Expanded widget guidance and documented header controls and alert visibility conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->