### PR TITLE
Keep the last good panel data when a refresh fails

### DIFF
--- a/dashboard/web/src/components/Panel.tsx
+++ b/dashboard/web/src/components/Panel.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import { Info, WarningCircle } from '@phosphor-icons/react';
 
 import type { Result } from '../types';
@@ -108,16 +108,12 @@ export function PanelStale({ result }: { result: { reason: string; hint?: string
   );
 }
 
-/**
- * Remembers the most recent payload that was actually available.
- *
- * Assigning during render is safe here because it's derived purely from props
- * and is idempotent — the same `data` always produces the same assignment, so a
- * double render under StrictMode can't skew it.
- */
+/** Remembers the most recent payload that was actually available. */
 function useLastAvailable<T extends object>(data: Result<T> | null): T | null {
   const lastAvailable = useRef<T | null>(null);
-  if (data?.available) lastAvailable.current = data;
+  useEffect(() => {
+    if (data?.available) lastAvailable.current = data;
+  }, [data]);
   return lastAvailable.current;
 }
 

--- a/dashboard/web/src/components/Panel.tsx
+++ b/dashboard/web/src/components/Panel.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import { Info } from '@phosphor-icons/react';
+import { useRef, type ReactNode } from 'react';
+import { Info, WarningCircle } from '@phosphor-icons/react';
 
 import type { Result } from '../types';
 
@@ -69,6 +69,58 @@ export function PanelEmpty({ result }: { result: { reason: string; hint?: string
   );
 }
 
+/**
+ * Shown above a panel's content when the newest response was unavailable but an
+ * earlier one wasn't.
+ *
+ * An upstream declining once is not a reason to throw away data that is seconds
+ * old — but it is a reason to say so, because silently showing stale numbers is
+ * worse than showing none. Carries the same reason and hint `PanelEmpty` would,
+ * so the fix stays discoverable without the panel going blank.
+ */
+export function PanelStale({ result }: { result: { reason: string; hint?: string } }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 'var(--space-2)',
+        alignItems: 'flex-start',
+        padding: 'var(--space-2) var(--space-3)',
+        borderRadius: 'var(--radius-sm)',
+        background: 'color-mix(in srgb, var(--ap-amber) 12%, transparent)',
+      }}
+    >
+      <WarningCircle
+        size={14}
+        color="var(--ap-amber)"
+        weight="regular"
+        style={{ flex: 'none', marginTop: 2 }}
+      />
+      <div style={{ minWidth: 0, fontSize: 12 }}>
+        <span>Showing last known data — {result.reason}</span>
+        {result.hint && (
+          <div className="text-muted" style={{ marginTop: 2 }}>
+            {result.hint}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Remembers the most recent payload that was actually available.
+ *
+ * Assigning during render is safe here because it's derived purely from props
+ * and is idempotent — the same `data` always produces the same assignment, so a
+ * double render under StrictMode can't skew it.
+ */
+function useLastAvailable<T extends object>(data: Result<T> | null): T | null {
+  const lastAvailable = useRef<T | null>(null);
+  if (data?.available) lastAvailable.current = data;
+  return lastAvailable.current;
+}
+
 /** Placeholder while a panel's first request is in flight. */
 export function PanelLoading() {
   return (
@@ -98,6 +150,20 @@ export function PanelBody<T extends object>({
   empty?: string;
   children: (value: T) => ReactNode;
 }) {
+  const lastAvailable = useLastAvailable(data);
+
+  const render = (value: T) => {
+    const rendered = children(value);
+    if (empty && Array.isArray(rendered) && rendered.length === 0) {
+      return (
+        <span className="text-muted" style={{ fontSize: 13 }}>
+          {empty}
+        </span>
+      );
+    }
+    return <>{rendered}</>;
+  };
+
   if (loading && !data) return <PanelLoading />;
   // A transport failure leaves `data` null with `loading` false. Reporting that
   // as "No response yet" would imply the request is still coming.
@@ -112,15 +178,24 @@ export function PanelBody<T extends object>({
       />
     );
   }
-  if (!data.available) return <PanelEmpty result={data} />;
 
-  const rendered = children(data);
-  if (empty && Array.isArray(rendered) && rendered.length === 0) {
-    return (
-      <span className="text-muted" style={{ fontSize: 13 }}>
-        {empty}
-      </span>
-    );
+  if (!data.available) {
+    // An upstream blip arrives as a *successful* response carrying
+    // `available: false`, so `usePolled` can't tell it from real data and
+    // replaces the last good payload with it. Without this branch a single
+    // failed poll blanks the panel until the server-side TTL lapses — up to a
+    // minute for the calendar — which is exactly what "a failed refresh keeps
+    // the last good data on screen" is supposed to prevent.
+    if (lastAvailable) {
+      return (
+        <>
+          <PanelStale result={data} />
+          {render(lastAvailable)}
+        </>
+      );
+    }
+    return <PanelEmpty result={data} />;
   }
-  return <>{rendered}</>;
+
+  return render(data);
 }


### PR DESCRIPTION
Follows up the `memoize` finding from the #51 review. Investigating it turned up something larger than the finding described.

## The bug

`usePolled`'s docstring promises "a failed refresh keeps the last good data on screen." It can only honour that for **transport** failures. An upstream declining arrives as a *successful* `200` carrying `available: false`, so `setData(json)` replaced the last good payload with it and `PanelBody` fell through to `PanelEmpty`.

Probing the real `memoize` shows the server side compounding it:

```
1. upstream healthy                {"available":true,"rows":4}
2. upstream blips, TTL expired     {"available":false,"reason":"connection refused"}
3. next poll, still within new TTL {"available":false,"reason":"connection refused"}
4. upstream recovered (cached)     {"available":false,"reason":"connection refused"}   <-- still failing
5. after TTL expires again         {"available":true,"rows":4}
```

Step 4 is the part the review didn't mention: the cached failure is served for the **whole TTL even after the upstream is healthy**. Combined, a single failed poll blanked a panel for up to **60s (Upcoming)** or **30s (Requests, Activity)** — the exact outcome the invariant exists to prevent.

## The fix

`PanelBody` remembers the most recent `available` payload and keeps rendering it when a later response is unavailable, above a marker naming the reason and carrying the same hint `PanelEmpty` would.

Staleness is stated, not hidden — silently showing stale numbers would be worse than showing none, and the hint keeps the fix discoverable without the panel going blank.

## Why not fix `memoize`

The review proposed making `memoize` retain the last good value. I deliberately didn't:

- It's generic over `T` and knows nothing about `Result`; teaching it the discriminant couples the cache to the payload type.
- Caching failures is **protective** — it's what stops a dead upstream being hit every five seconds.
- Retaining server-side risks serving stale data indefinitely with no signal, whereas the client can *show* staleness.

The display decision belongs where `Result` is already understood.

## Verification

End to end against a live Seerr behind a toggleable proxy, without reloading between steps (a reload would reset the retained value and prove nothing):

1. Healthy — four request rows render
2. Upstream returns 503 — rows **stay**, marker appears: `Showing last known data — HTTP 503`
3. Upstream healed — marker clears, rows refresh

Also confirmed the first-load case is untouched: with no prior good payload, an unavailable response still renders `PanelEmpty`.

Typecheck, lint, 42/42 tests and build all clean.

## Not covered

`Gauges` and `VpnCard` don't use `PanelBody` and still drop upstream reasons — the other half of that review finding. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Panels now continue displaying the most recently available data when an upstream update is temporarily unavailable.
  * Added a clear “Showing last known data” warning to indicate that displayed information may be stale.
  * Panels without previously available data continue to show the appropriate empty state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->